### PR TITLE
Add preg_quote to except and only filters

### DIFF
--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -78,7 +78,7 @@ class ShouldCollect
 		if (! count($this->except)) return true;
 
 		foreach ($this->except as $pattern) {
-			if (preg_match('#' . str_replace('#', '\#', $pattern) . '#', $request->uri)) return false;
+			if (preg_match('#' . preg_quote($pattern) . '#', $request->uri)) return false;
 		}
 
 		return true;
@@ -89,7 +89,7 @@ class ShouldCollect
 		if (! count($this->only)) return true;
 
 		foreach ($this->only as $pattern) {
-			if (preg_match('#' . str_replace('#', '\#', $pattern) . '#', $request->uri)) return true;
+			if (preg_match('#' . preg_quote($pattern) . '#', $request->uri)) return true;
 		}
 
 		return false;

--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -78,7 +78,7 @@ class ShouldCollect
 		if (! count($this->except)) return true;
 
 		foreach ($this->except as $pattern) {
-			if (preg_match('#' . preg_quote($pattern) . '#', $request->uri)) return false;
+			if (preg_match('#' . str_replace('#', '\#', $pattern) . '#', $request->uri)) return false;
 		}
 
 		return true;
@@ -89,7 +89,7 @@ class ShouldCollect
 		if (! count($this->only)) return true;
 
 		foreach ($this->only as $pattern) {
-			if (preg_match('#' . preg_quote($pattern) . '#', $request->uri)) return true;
+			if (preg_match('#' . str_replace('#', '\#', $pattern) . '#', $request->uri)) return true;
 		}
 
 		return false;

--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -239,7 +239,7 @@ class Clockwork
 		]);
 
 		// don't collect data for Clockwork requests
-		$this->clockwork->shouldCollect()->except(rtrim($this->config['api'], '/'));
+		$this->clockwork->shouldCollect()->except(preg_quote(rtrim($this->config['api'], '/'), '#'));
 	}
 
 	// Configure should record rules based on user configuration


### PR DESCRIPTION
Previous version did not quoted except and only filters in ShouldCollect, so following example did not preg_match because question symbol is special: `index.php?some_param`.

This commit add preg_quote($pattern) to properly escape special regex symbols in the pattern.